### PR TITLE
User certificate data fix

### DIFF
--- a/config/kube/user.go
+++ b/config/kube/user.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 )
 
 type User struct {
@@ -47,9 +48,11 @@ func (u *User) loadCertificateFiles() (tls.Certificate, error, bool) {
 }
 
 func (u *User) loadCertificateData() (tls.Certificate, error, bool) {
-	cert, err := tls.LoadX509KeyPair(
-		u.ClientCertificateData,
-		u.ClientKeyData,
+	certData, _ := base64.StdEncoding.DecodeString(u.ClientCertificateData)
+	keyData, _ := 	base64.StdEncoding.DecodeString(u.ClientKeyData)
+	cert, err := tls.X509KeyPair(
+		certData,
+		keyData,
 	)
 
 	if err != nil {

--- a/config/kube/user.go
+++ b/config/kube/user.go
@@ -48,8 +48,8 @@ func (u *User) loadCertificateFiles() (tls.Certificate, error, bool) {
 
 func (u *User) loadCertificateData() (tls.Certificate, error, bool) {
 	cert, err := tls.LoadX509KeyPair(
-		u.ClientCertificate,
-		u.ClientKey,
+		u.ClientCertificateData,
+		u.ClientKeyData,
 	)
 
 	if err != nil {

--- a/config/kube/user.go
+++ b/config/kube/user.go
@@ -48,8 +48,14 @@ func (u *User) loadCertificateFiles() (tls.Certificate, error, bool) {
 }
 
 func (u *User) loadCertificateData() (tls.Certificate, error, bool) {
-	certData, _ := base64.StdEncoding.DecodeString(u.ClientCertificateData)
-	keyData, _ := base64.StdEncoding.DecodeString(u.ClientKeyData)
+	certData, err := base64.StdEncoding.DecodeString(u.ClientCertificateData)
+	if err != nil {
+		return tls.Certificate{}, err, false
+	}
+	keyData, err := base64.StdEncoding.DecodeString(u.ClientKeyData)
+	if err != nil {
+		return tls.Certificate{}, err, false
+	}
 	cert, err := tls.X509KeyPair(
 		certData,
 		keyData,

--- a/config/kube/user.go
+++ b/config/kube/user.go
@@ -49,7 +49,7 @@ func (u *User) loadCertificateFiles() (tls.Certificate, error, bool) {
 
 func (u *User) loadCertificateData() (tls.Certificate, error, bool) {
 	certData, _ := base64.StdEncoding.DecodeString(u.ClientCertificateData)
-	keyData, _ := 	base64.StdEncoding.DecodeString(u.ClientKeyData)
+	keyData, _ := base64.StdEncoding.DecodeString(u.ClientKeyData)
 	cert, err := tls.X509KeyPair(
 		certData,
 		keyData,


### PR DESCRIPTION
This handles the case where `client-certificate-data` is base64 encoded in the file.